### PR TITLE
Add custom snapping support

### DIFF
--- a/lib/commands/commanditemmove.cpp
+++ b/lib/commands/commanditemmove.cpp
@@ -5,7 +5,7 @@
 
 using namespace QSchematic;
 
-CommandItemMove::CommandItemMove(const QVector<QPointer<Item>>& items, const QVector2D& moveBy, QUndoCommand* parent) :
+CommandItemMove::CommandItemMove(const QVector<std::shared_ptr<Item>>& items, const QVector2D& moveBy, QUndoCommand* parent) :
     QUndoCommand(parent),
     _items(items),
     _moveBy(moveBy)

--- a/lib/commands/commanditemmove.h
+++ b/lib/commands/commanditemmove.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <memory>
 #include <QUndoCommand>
 #include <QVector>
-#include <QPointer>
 #include <QVector2D>
 
 class QVector2D;
@@ -14,7 +14,7 @@ namespace QSchematic
     class CommandItemMove : public QUndoCommand
     {
     public:
-        CommandItemMove(const QVector<QPointer<Item>>& item, const QVector2D& moveBy, QUndoCommand* parent = nullptr);
+        CommandItemMove(const QVector<std::shared_ptr<Item>>& item, const QVector2D& moveBy, QUndoCommand* parent = nullptr);
 
         virtual int id() const override;
         virtual bool mergeWith(const QUndoCommand* command) override;
@@ -22,7 +22,7 @@ namespace QSchematic
         virtual void redo() override;
 
     private:
-        QVector<QPointer<Item>> _items;
+        QVector<std::shared_ptr<Item>> _items;
         QVector2D _moveBy;
     };
 

--- a/lib/scene.h
+++ b/lib/scene.h
@@ -80,6 +80,11 @@ namespace QSchematic {
         virtual void dropEvent(QGraphicsSceneDragDropEvent* event) override;
         virtual void drawBackground(QPainter* painter, const QRectF& rect) override;
 
+        /* This gets called just before the item is actually being moved by moveBy. Subclasses may
+         * implement this to implement snapping to elements other than the grid
+         */
+        virtual QVector2D itemsMoveSnap(const std::shared_ptr<Item>& item, const QVector2D& moveBy) const;
+
     private:
         void renderCachedBackground();
         void setupNewItem(Item& item);
@@ -97,6 +102,8 @@ namespace QSchematic {
         bool _invertWirePosture;
         QPointF _lastMousePos;
         QList<std::shared_ptr<Item>> _selectedItems;
+        QMap<std::shared_ptr<Item>, QPointF> _initialItemPositions;
+        QPointF _initialCursorPosition;
         std::unique_ptr<QGraphicsProxyWidget> _popupInfobox;
         QUndoStack* _undoStack;
 


### PR DESCRIPTION
Summary: Add support for scene wide custom snapping

Test Plan: Subclass QSchematic::Scene and override QSchematic::Scene::itemsMoveSnap

Reviewers: Joel

Reviewed By: Joel

Differential Revision: https://phabricator.simulton.com/D58