### PR TITLE
Map rotation to 0-360 range

### DIFF
--- a/lib/items/node.cpp
+++ b/lib/items/node.cpp
@@ -523,7 +523,7 @@ void Node::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
 
         auto center = sizeRect().center() + pos();
         auto delta = center - newMousePos;
-        auto angle = qAtan2(delta.ry(), delta.rx())*180/M_PI - 90;
+        auto angle = fmod(qAtan2(delta.ry(), delta.rx())*180/M_PI + 270, 360);
         if (QApplication::keyboardModifiers() == Qt::ShiftModifier) {
             angle = qRound(angle/15)*15;
         }


### PR DESCRIPTION
Summary: Map the rotation of nodes to be in the range 0 to 360.

Test Plan: Log the rotation in Node::mouseMoveEvent and check if it doesn't go over 360 or under 0.

Reviewers: Joel

Reviewed By: Joel

Differential Revision: https://phabricator.simulton.com/D63