### PR TITLE
Move wire points when rotating nodes

### DIFF
--- a/demos/demo_01/application/items/fancywire.cpp
+++ b/demos/demo_01/application/items/fancywire.cpp
@@ -66,14 +66,12 @@ void FancyWire::paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
     painter->setPen(pen);
     painter->setBrush(brush);
     const auto& points = pointsAbsolute();
-    auto it = points.constBegin();
-    while (it != points.constEnd()) {
-        const auto& point = it->toPoint();
-
-        if (connectionPoints.contains(point)) {
-            painter->drawEllipse(point, SIZE, SIZE);
+    for (const auto& point: pointsAbsolute()) {
+        for (const auto& connector: connectionPoints) {
+            if (qFuzzyCompare(QVector2D(connector), QVector2D(point))) {
+                painter->drawEllipse(point, SIZE, SIZE);
+                break;
+            }
         }
-
-        it++;
     }
 }

--- a/lib/items/item.cpp
+++ b/lib/items/item.cpp
@@ -30,6 +30,7 @@ Item::Item(int type, QGraphicsItem* parent) :
     setFlag(QGraphicsItem::ItemIsMovable, true);
     connect(this, &Item::xChanged, this, &Item::posChanged);
     connect(this, &Item::yChanged, this, &Item::posChanged);
+    connect(this, &Item::rotationChanged, this, &Item::rotChanged);
 }
 
 Gpds::Container Item::toContainer() const
@@ -72,6 +73,7 @@ void Item::copyAttributes(Item& dest) const
     dest._highlightEnabled = _highlightEnabled;
     dest._highlighted = _highlighted;
     dest._oldPos = _oldPos;
+    dest._oldRot = _oldRot;
 }
 
 void Item::addItemTypeIdToContainer(Gpds::Container& container) const
@@ -363,6 +365,17 @@ void Item::posChanged()
     }
 
     _oldPos = newPos;
+}
+
+void Item::rotChanged()
+{
+    const qreal newRot = rotation();
+    qreal rotationChange = newRot - _oldRot;
+    if (!qFuzzyIsNull(rotationChange)) {
+        emit rotated(*this, rotationChange);
+    }
+
+    _oldRot = newRot;
 }
 
 void Item::update()

--- a/lib/items/item.h
+++ b/lib/items/item.h
@@ -77,6 +77,7 @@ namespace QSchematic {
 
     signals:
         void moved(Item& item, const QVector2D& movedBy);
+        void rotated(Item& item, const qreal rotation);
         void showPopup(const Item& item);
         void highlightChanged(const Item& item, bool isHighlighted);
         void settingsChanged();
@@ -97,6 +98,7 @@ namespace QSchematic {
 
     private slots:
         void posChanged();
+        void rotChanged();
 
     private:
         int _type;
@@ -104,6 +106,7 @@ namespace QSchematic {
         bool _highlightEnabled;
         bool _highlighted;
         QPointF _oldPos;
+        qreal _oldRot;
         QTimer* _hoverTimer;
     };
 

--- a/lib/items/node.cpp
+++ b/lib/items/node.cpp
@@ -269,7 +269,17 @@ QList<QPointF> Node::connectionPointsRelative() const
     QList<QPointF> list;
 
     for (const auto& connector : _connectors) {
-        list << connector->connectionPoint() + connector->pos();
+        QPointF pos = connector->pos();
+        // Rotate the position around to the node's origin
+        {
+            QPointF d = transformOriginPoint() - pos;
+            qreal angle = rotation() * M_PI / 180;
+            QPointF rotated;
+            rotated.setX(qCos(angle) * d.rx() - qSin(angle) * d.ry());
+            rotated.setY(qSin(angle) * d.rx() + qCos(angle) * d.ry());
+            pos = transformOriginPoint() - rotated;
+        }
+        list << connector->connectionPoint() + pos;
     }
 
     return list;

--- a/lib/items/wire.cpp
+++ b/lib/items/wire.cpp
@@ -148,7 +148,7 @@ QVector<QPointF> Wire::pointsRelative() const
     QVector<QPointF> points;
 
     for (const WirePoint& point : _points) {
-        points << point.toPoint();
+        points << point.toPointF();
     }
 
     return points;
@@ -287,9 +287,9 @@ void Wire::removeObsoletePoints(QVector<WirePoint>& points)
     // Compile a list of obsolete points
     auto it = points.begin()+2;
     while (it != points.end()) {
-        QPoint p1 = (*(it - 2)).toPoint();
-        QPoint p2 = (*(it - 1)).toPoint();
-        QPoint p3 = (*it).toPoint();
+        QPointF p1 = (*(it - 2)).toPointF();
+        QPointF p2 = (*(it - 1)).toPointF();
+        QPointF p3 = (*it).toPointF();
 
         // Check if p2 is on the line created by p1 and p3
         if (Utils::pointIsOnLine(QLineF(p1, p2), p3)) {
@@ -307,7 +307,7 @@ void Wire::movePointBy(int index, const QVector2D& moveBy)
     }
 
     prepareGeometryChange();
-    _points[index] = WirePoint(_points.at(index).toPoint() + moveBy.toPoint());
+    _points[index] = WirePoint(_points.at(index).toPointF() + moveBy.toPointF());
     calculateBoundingRect();
     update();
 
@@ -370,7 +370,7 @@ QList<Line> Wire::lineSegments() const
 
     QList<Line> ret;
     for (int i = 0; i < _points.count()-1; i++) {
-        ret.append(Line(gridPos() + _points.at(i).toPoint(), gridPos() + _points.at(i+1).toPoint()));
+        ret.append(Line(QPointF(gridPos()) + _points.at(i).toPointF(), QPointF(gridPos()) + _points.at(i+1).toPointF()));
     }
 
     return ret;
@@ -584,7 +584,7 @@ void Wire::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWid
         if (wirePoint.isJunction()) {
             painter->setPen(penJunction);
             painter->setBrush(brushJunction);
-            painter->drawEllipse(wirePoint.toPoint(), junctionRadius, junctionRadius);
+            painter->drawEllipse(wirePoint.toPointF(), junctionRadius, junctionRadius);
         }
     }
 

--- a/lib/scene.h
+++ b/lib/scene.h
@@ -109,6 +109,7 @@ namespace QSchematic {
 
     private slots:
         void itemMoved(const Item& item, const QVector2D& movedBy);
+        void itemRotated(const Item& item, const qreal rotation);
         void wireNetHighlightChanged(bool highlighted);
         void wirePointMoved(Wire& wire, WirePoint& point);
         void wireMovePoint(const QPointF& point, Wire& wire, const QVector2D& movedBy) const;


### PR DESCRIPTION
Summary: Move the wires connected to a node when it rotates.

Test Plan: Connect a wire to a node and rotate it. The wire should stay connected to the node.

Reviewers: Joel

Differential Revision: https://phabricator.simulton.com/D65