### PR TITLE
Make GPSD optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,18 @@ project(qschematic)
 
 # User options
 option(QSCHEMATIC_BUILD_DEMO "Whether to build the demo project" ON)
-option(QSCHEMATIC_DEPENDENCY_GPDS_DOWNLOAD "Whether to pull the GPDS dependency via FetchContent" ON)
+option(QSCHEMATIC_USE_GPDS "Whether to use GPDS dependency to save and load files" ON)
 
+#GPDS options and settings
+if (QSCHEMATIC_USE_GPDS)
+    option(QSCHEMATIC_DEPENDENCY_GPDS_DOWNLOAD "Whether to pull the GPDS dependency via FetchContent" ON)
+    set(QSCHEMATIC_DEPENDENCY_GPDS_TARGET "gpds-static" CACHE STRING "The CMake target of the GPDS library to use")
+    add_compile_definitions(USE_GPDS)
+endif()
 # User settings
-set(QSCHEMATIC_DEPENDENCY_GPDS_TARGET "gpds-static" CACHE STRING "The CMake target of the GPDS library to use")
 set(CMAKE_DEBUG_POSTFIX d)
+
+#set(CMAKE_VERBOSE_MAKEFILE ON)
 
 # Include the library
 add_subdirectory(qschematic)
@@ -25,10 +32,12 @@ message("-------------------------")
 message("QSchematic configuration:")
 message("  Build")
 message("    Demo       : " ${QSCHEMATIC_BUILD_DEMO})
-message("  Dependencies")
-message("    GPDS")
-message("      Download : " ${QSCHEMATIC_DEPENDENCY_GPDS_DOWNLOAD})
-message("      Target   : " ${QSCHEMATIC_DEPENDENCY_GPDS_TARGET})
+if (QSCHEMATIC_USE_GPDS)
+    message("  Dependencies")
+    message("    GPDS")
+    message("      Download : " ${QSCHEMATIC_DEPENDENCY_GPDS_DOWNLOAD})
+    message("      Target   : " ${QSCHEMATIC_DEPENDENCY_GPDS_TARGET})
+endif()
 message("-------------------------")
 message("")
 

--- a/qschematic/external.cmake
+++ b/qschematic/external.cmake
@@ -1,18 +1,20 @@
 include(FetchContent)
 
+if (QSCHEMATIC_USE_GPDS)
 # GPDS
-if (QSCHEMATIC_DEPENDENCY_GPDS_DOWNLOAD)
-    FetchContent_Declare(
-        gpds
-        GIT_REPOSITORY https://github.com/simulton/gpds
-        GIT_TAG        1.0.2
-    )
-    FetchContent_GetProperties(gpds)
-    if(NOT gpds_POPULATED)
-        FetchContent_Populate(gpds)
-        set(GPDS_BUILD_TESTS OFF CACHE INTERNAL "")
-        set(GPDS_BUILD_EXAMPLES OFF CACHE INTERNAL "")
-        add_subdirectory(${gpds_SOURCE_DIR} ${gpds_BINARY_DIR})
+    if (QSCHEMATIC_DEPENDENCY_GPDS_DOWNLOAD)
+      FetchContent_Declare(
+         gpds
+         GIT_REPOSITORY https://github.com/simulton/gpds
+            GIT_TAG        1.0.2
+        )
+     FetchContent_GetProperties(gpds)
+      if(NOT gpds_POPULATED)
+            FetchContent_Populate(gpds)
+           set(GPDS_BUILD_TESTS OFF CACHE INTERNAL "")
+          set(GPDS_BUILD_EXAMPLES OFF CACHE INTERNAL "")
+           add_subdirectory(${gpds_SOURCE_DIR} ${gpds_BINARY_DIR})
+        endif()
     endif()
 endif()
 

--- a/qschematic/items/connector.cpp
+++ b/qschematic/items/connector.cpp
@@ -52,7 +52,7 @@ Connector::~Connector()
     // So it's definitely removed via the shared_ptr (which we have by way of the item-allocation contracts being shptr all through
     dissociate_item(_label);
 }
-
+#ifdef USE_GPDS
 gpds::container Connector::to_container() const
 {
     // Root
@@ -75,7 +75,7 @@ void Connector::from_container(const gpds::container& container)
     _textDirection = static_cast<Direction>(container.get_value<int>("text_direction").value_or(LeftToRight));
     _label->from_container(*container.get_value<gpds::container*>("label").value());
 }
-
+#endif
 std::shared_ptr<Item> Connector::deepCopy() const
 {
     auto clone = std::make_shared<Connector>(type(), gridPos(), text(), parentItem());

--- a/qschematic/items/connector.h
+++ b/qschematic/items/connector.h
@@ -27,8 +27,10 @@ namespace QSchematic {
         Connector(int type = Item::ConnectorType, const QPoint& gridPos = QPoint(), const QString& text = QString(), QGraphicsItem* parent = nullptr);
         virtual ~Connector() override;
 
+#ifdef USE_GPDS
         virtual gpds::container to_container() const override;
         virtual void from_container(const gpds::container& container) override;
+#endif
         virtual std::shared_ptr<Item> deepCopy() const override;
 
         void setSnapPolicy(SnapPolicy policy);

--- a/qschematic/items/item.cpp
+++ b/qschematic/items/item.cpp
@@ -43,7 +43,7 @@ Item::~Item()
     // Q_ASSERT(SharedPtrTracker::assert_expired(this));
     Q_ASSERT(weakPtr().expired());
 }
-
+#ifdef USE_GPDS
 gpds::container Item::to_container() const
 {
     // Root
@@ -70,7 +70,7 @@ void Item::from_container(const gpds::container& container)
     setSnapToGrid(container.get_value<bool>("snap_to_grid").value_or(true));
     setHighlightEnabled(container.get_value<bool>("highlight").value_or(false));
 }
-
+#endif
 void Item::copyAttributes(Item& dest) const
 {
     // Base class
@@ -86,12 +86,12 @@ void Item::copyAttributes(Item& dest) const
     dest._oldPos = _oldPos;
     dest._oldRot = _oldRot;
 }
-
+#ifdef USE_GPDS
 void Item::addItemTypeIdToContainer(gpds::container& container) const
 {
     container.add_attribute( "type_id", type() );
 }
-
+#endif
 Scene* Item::scene() const
 {
     return qobject_cast<Scene*>(QGraphicsObject::scene());

--- a/qschematic/items/item.h
+++ b/qschematic/items/item.h
@@ -2,7 +2,9 @@
 
 #include <memory>
 #include <QGraphicsObject>
+#ifdef USE_GPDS
 #include <gpds/serialize.hpp>
+#endif
 #include "../types.h"
 #include "../settings.h"
 #include "itemfunctions.h"
@@ -17,7 +19,9 @@ namespace QSchematic
 
     class QSCHEMATIC_EXPORT Item :
         public QGraphicsObject,
+#ifdef USE_GPDS
         public gpds::serialize,
+#endif
         public std::enable_shared_from_this<Item>
     {
         Q_OBJECT
@@ -84,8 +88,10 @@ namespace QSchematic
         }
         /// @}
 
+#ifdef USE_GPDS
         virtual gpds::container to_container() const override;
         virtual void from_container(const gpds::container& container) override;
+#endif
         virtual std::shared_ptr<Item> deepCopy() const = 0;
 
         int type() const final;
@@ -135,7 +141,9 @@ namespace QSchematic
         Settings _settings;
 
         void copyAttributes(Item& dest) const;
+#ifdef USE_GPDS
         void addItemTypeIdToContainer(gpds::container& container) const;
+#endif
 
         bool isHighlighted() const;
         virtual QVariant itemChange(QGraphicsItem::GraphicsItemChange change, const QVariant& value) override;

--- a/qschematic/items/itemfactory.cpp
+++ b/qschematic/items/itemfactory.cpp
@@ -14,7 +14,7 @@ ItemFactory& ItemFactory::instance()
 
     return instance;
 }
-
+#ifdef USE_GPDS
 void ItemFactory::setCustomItemsFactory(const std::function<std::shared_ptr<Item>(const gpds::container&)>& factory)
 {
     _customItemFactory = factory;
@@ -63,3 +63,4 @@ Item::ItemType ItemFactory::extractType(const gpds::container& container)
 {
     return static_cast<Item::ItemType>( container.get_attribute<int>( "type_id" ).value_or( -1 ) );
 }
+#endif

--- a/qschematic/items/itemfactory.h
+++ b/qschematic/items/itemfactory.h
@@ -16,17 +16,19 @@ namespace QSchematic
     {
     public:
         static ItemFactory& instance();
-
+#ifdef USE_GPDS
         void setCustomItemsFactory(const std::function<std::shared_ptr<Item>(const gpds::container&)>& factory);
         std::shared_ptr<Item> from_container(const gpds::container& container) const;
         static Item::ItemType extractType(const gpds::container& container);
+#endif
 
     private:
         ItemFactory() = default;
         ItemFactory(const ItemFactory& other) = default;
         ItemFactory(ItemFactory&& other) = default;
-
+#ifdef USE_GPDS
         std::function<std::shared_ptr<Item>(const gpds::container&)> _customItemFactory;
+#endif
     };
 
 }

--- a/qschematic/items/label.cpp
+++ b/qschematic/items/label.cpp
@@ -17,7 +17,7 @@ Label::Label(int type, QGraphicsItem* parent) :
 {
     setSnapToGrid(false);
 }
-
+#ifdef USE_GPDS
 gpds::container Label::to_container() const
 {
     // Connection point
@@ -52,7 +52,7 @@ void Label::from_container(const gpds::container& container)
         _connectionPoint.setY(connectionPointContainer->get_value<double>("y").value_or(0));
     }
 }
-
+#endif
 std::shared_ptr<Item> Label::deepCopy() const
 {
     auto clone = std::make_shared<Label>(type(), parentItem());

--- a/qschematic/items/label.h
+++ b/qschematic/items/label.h
@@ -23,8 +23,10 @@ namespace QSchematic {
         Label(int type = Item::LabelType, QGraphicsItem* parent = nullptr);
         virtual ~Label() override = default;
 
+#ifdef USE_GPDS
         virtual gpds::container to_container() const override;
         virtual void from_container(const gpds::container& container) override;
+#endif
         virtual std::shared_ptr<Item> deepCopy() const override;
 
         virtual QRectF boundingRect() const final;

--- a/qschematic/items/node.cpp
+++ b/qschematic/items/node.cpp
@@ -41,7 +41,7 @@ Node::~Node()
     dissociate_items(_connectors);
     dissociate_items(_specialConnectors);
 }
-
+#ifdef USE_GPDS
 gpds::container Node::to_container() const
 {
     // Connectors configuration
@@ -104,7 +104,7 @@ void Node::from_container(const gpds::container& container)
         }
     }
 }
-
+#endif
 std::shared_ptr<Item> Node::deepCopy() const
 {
     auto clone = std::make_shared<Node>(type(), parentItem());

--- a/qschematic/items/node.h
+++ b/qschematic/items/node.h
@@ -33,8 +33,10 @@ namespace QSchematic {
         Node(int type = Item::NodeType, QGraphicsItem* parent = nullptr);
         virtual ~Node() override;
 
+#ifdef USE_GPDS
         virtual gpds::container to_container() const override;
         virtual void from_container(const gpds::container& container) override;
+#endif
         virtual std::shared_ptr<Item> deepCopy() const override;
 
         Mode mode() const;

--- a/qschematic/items/wire.cpp
+++ b/qschematic/items/wire.cpp
@@ -59,7 +59,7 @@ Wire::~Wire()
         }
     }
 }
-
+#ifdef USE_GPDS
 gpds::container Wire::to_container() const
 {
     // Points
@@ -108,7 +108,7 @@ void Wire::from_container(const gpds::container& container)
 
     update();
 }
-
+#endif
 std::shared_ptr<Item> Wire::deepCopy() const
 {
     auto clone = std::make_shared<Wire>(type(), parentItem());

--- a/qschematic/items/wire.h
+++ b/qschematic/items/wire.h
@@ -27,8 +27,10 @@ namespace QSchematic {
         virtual ~Wire() override;
         virtual void update() override;
 
+#ifdef USE_GPDS
         virtual gpds::container to_container() const override;
         virtual void from_container(const gpds::container& container) override;
+#endif
         virtual std::shared_ptr<Item> deepCopy() const override;
         virtual QRectF boundingRect() const override;
         virtual QPainterPath shape() const override;

--- a/qschematic/items/wirenet.cpp
+++ b/qschematic/items/wirenet.cpp
@@ -33,7 +33,7 @@ WireNet::~WireNet()
     if (_label)
         dissociate_item(_label);
 }
-
+#ifdef USE_GPDS
 gpds::container WireNet::to_container() const
 {
     // Wires
@@ -94,7 +94,7 @@ void WireNet::from_container(const gpds::container& container)
         }
     }
 }
-
+#endif
 bool WireNet::addWire(const std::shared_ptr<wire>& wire)
 {
     if (!net::addWire(wire)) {

--- a/qschematic/items/wirenet.h
+++ b/qschematic/items/wirenet.h
@@ -3,7 +3,9 @@
 #include <memory>
 #include <QObject>
 #include <QList>
+#ifdef USE_GPDS
 #include <gpds/serialize.hpp>
+#endif
 
 #include "wire_system/line.h"
 #include "wire_system/net.h"
@@ -24,7 +26,9 @@ namespace QSchematic {
 
     class QSCHEMATIC_EXPORT WireNet :
         public QObject,
+#ifdef USE_GPDS
         public gpds::serialize,
+#endif
         public wire_system::net
     {
         Q_OBJECT
@@ -34,8 +38,10 @@ namespace QSchematic {
         WireNet(QObject* parent = nullptr);
         virtual ~WireNet()  override;
 
+#ifdef USE_GPDS
         virtual gpds::container to_container() const override;
         virtual void from_container(const gpds::container& container) override;
+#endif
 
         bool addWire(const std::shared_ptr<wire>& wire) override;
         bool removeWire(const std::shared_ptr<wire> wire) override;

--- a/qschematic/items/wireroundedcorners.cpp
+++ b/qschematic/items/wireroundedcorners.cpp
@@ -19,7 +19,7 @@ WireRoundedCorners::WireRoundedCorners(int type, QGraphicsItem* parent) :
     Wire(type, parent)
 {
 }
-
+#ifdef USE_GPDS
 gpds::container WireRoundedCorners::to_container() const
 {
     // Root
@@ -35,7 +35,7 @@ void WireRoundedCorners::from_container(const gpds::container& container)
     auto opt = container.get_value<gpds::container*>("wire");
     Wire::from_container(opt ? *opt.value() : gpds::container());
 }
-
+#endif
 void WireRoundedCorners::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget)
 {
     Q_UNUSED(option);

--- a/qschematic/items/wireroundedcorners.h
+++ b/qschematic/items/wireroundedcorners.h
@@ -16,8 +16,10 @@ namespace QSchematic
         WireRoundedCorners(int type = Item::WireRoundedCornersType, QGraphicsItem* parent = nullptr);
         virtual ~WireRoundedCorners() override = default;
 
+#ifdef USE_GPDS
         virtual gpds::container to_container() const override;
         virtual void from_container(const gpds::container& container) override;
+#endif
         virtual void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget = nullptr) override;
 
     private:

--- a/qschematic/scene.cpp
+++ b/qschematic/scene.cpp
@@ -51,7 +51,7 @@ Scene::Scene(QObject* parent) :
     // Prepare the background
     renderCachedBackground();
 }
-
+#ifdef USE_GPDS
 gpds::container Scene::to_container() const
 {
     // Scene
@@ -157,7 +157,7 @@ void Scene::from_container(const gpds::container& container)
     // Clear the undo history
     _undoStack->clear();
 }
-
+#endif
 void Scene::setSettings(const Settings& settings)
 {
     // Update settings of all items

--- a/qschematic/scene.h
+++ b/qschematic/scene.h
@@ -5,7 +5,9 @@
 #include <functional>
 #include <QGraphicsScene>
 #include <QUndoStack>
+#ifdef USE_GPDS
 #include <gpds/serialize.hpp>
+#endif
 #include "wire_system/manager.h"
 #include "settings.h"
 #include "items/item.h"
@@ -20,8 +22,10 @@ namespace QSchematic {
     class WireNet;
 
     class QSCHEMATIC_EXPORT Scene :
-        public QGraphicsScene,
-        public gpds::serialize
+        public QGraphicsScene
+#ifdef USE_GPDS
+        ,public gpds::serialize
+#endif
     {
         Q_OBJECT
         Q_DISABLE_COPY(Scene)
@@ -38,8 +42,10 @@ namespace QSchematic {
         explicit Scene(QObject* parent = nullptr);
         virtual ~Scene() override = default;
 
+#ifdef USE_GPDS
         virtual gpds::container to_container() const override;
         virtual void from_container(const gpds::container& container) override;
+#endif
 
         void setSettings(const Settings& settings);
         void setWireFactory(const std::function<std::shared_ptr<Wire>()>& factory);


### PR DESCRIPTION
When using EDIF, OpenAccess(short OA) or other Netlist formats GPSD is a not needed Dependency.
This change makes GPSD optional in the CMakeLists.txt

The provided tests on the wire system still pass.