### PR TITLE
utils: fix Q_ASSERT check on nearestEdge

### DIFF
--- a/qschematic/utils.cpp
+++ b/qschematic/utils.cpp
@@ -45,7 +45,7 @@ Utils::clipPointToRectOutline(QPointF point, const QRectF& rect)
 
     // Figure out to which edge we're closest to
     const auto& nearestEdge = Utils::lineClosestToPoint(edges, point);
-    Q_ASSERT(nearestEdge);
+    Q_ASSERT(nearestEdge != edges.cend());
 
     // Snap to that edge
     point = Utils::pointOnLineClosestToPoint(nearestEdge->p1(), nearestEdge->p2(), point);


### PR DESCRIPTION
- fix build error when using qt-6.6.0
- optimized the target of Q_ASSERT check to make it more rigorous

Closes: https://github.com/simulton/QSchematic/issues/46