### PR TITLE
view: Adapt to Qt 6 MouseEvent API changes

### DIFF
--- a/qschematic/view.cpp
+++ b/qschematic/view.cpp
@@ -127,8 +127,13 @@ View::mouseMoveEvent(QMouseEvent* event)
             break;
 
         case PanMode:
+#       if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            horizontalScrollBar()->setValue(horizontalScrollBar()->value() - (event->position().x() - _panStart.x()));
+            verticalScrollBar()->setValue(verticalScrollBar()->value() - (event->position().y() - _panStart.y()));
+#       else
             horizontalScrollBar()->setValue(horizontalScrollBar()->value() - (event->x() - _panStart.x()));
             verticalScrollBar()->setValue(verticalScrollBar()->value() - (event->y() - _panStart.y()));
+#       endif
             _panStart = event->pos();
             event->accept();
             return;


### PR DESCRIPTION
- Replace deprecated QMouseEvent::x() and y() with position() for Qt version >= 6.0.0, addressing deprecation warnings
- Maintain compatibility with earlier Qt versions

See also: https://doc.qt.io/qt-6.2/qmouseevent-obsolete.html