### PR TITLE
wirenet: Fix deprecation warnings in C++20 for lambda captures

### DIFF
--- a/qschematic/items/wirenet.cpp
+++ b/qschematic/items/wirenet.cpp
@@ -18,10 +18,10 @@ WireNet::WireNet(QObject* parent) :
     _label->setPos(0, 0);
     _label->setVisible(false);
     connect(_label.get(), &Label::highlightChanged, this, &WireNet::labelHighlightChanged);
-    connect(_label.get(), &Label::moved, this, [=] { updateLabelPos(); });
+    connect(_label.get(), &Label::moved, this, [this] { updateLabelPos(); });
 
     // Rename net by double clicking on label
-    connect(_label.get(), &Label::doubleClicked, this, [=] {
+    connect(_label.get(), &Label::doubleClicked, this, [this] {
         Wire* wire = dynamic_cast<Wire*>(_label->parentItem());
         if (wire) {
             wire->rename_net();
@@ -108,7 +108,7 @@ bool WireNet::addWire(const std::shared_ptr<wire>& wire)
         connect(wire_net.get(), &Wire::pointMoved, this, &WireNet::wirePointMoved);
         connect(wire_net.get(), &Wire::highlightChanged, this, &WireNet::wireHighlightChanged);
         connect(wire_net.get(), &Wire::toggleLabelRequested, this, &WireNet::toggleLabel);
-        connect(wire_net.get(), &Wire::moved, this, [=] { updateLabelPos(); });
+        connect(wire_net.get(), &Wire::moved, this, [this] { updateLabelPos(); });
     }
 
 


### PR DESCRIPTION
- Explicitly capture 'this' in lambdas to comply with C++20 (ISO/IEC 14882:2020) standards, addressing deprecation warnings for implicit 'this' capture.
- These changes retain compatibility with earlier C++ standards, ensuring the code works seamlessly across different C++ versions.