### PR TITLE
Fix initial scale factor of View

### DIFF
--- a/qschematic/view.cpp
+++ b/qschematic/view.cpp
@@ -11,8 +11,7 @@
 using namespace QSchematic;
 
 View::View(QWidget* parent) :
-    QGraphicsView(parent),
-    _scaleFactor(qLn(zoom_factor_min/1.0) / qLn(zoom_factor_min / zoom_factor_max))
+    QGraphicsView(parent)
 {
     // Scroll bars
     setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
@@ -25,6 +24,9 @@ View::View(QWidget* parent) :
 
     // Rendering options
     setViewportUpdateMode(QGraphicsView::FullViewportUpdate);
+
+    // Set initial zoom value
+    setZoomValue(1.0);
 }
 
 void

--- a/qschematic/view.cpp
+++ b/qschematic/view.cpp
@@ -11,7 +11,8 @@
 using namespace QSchematic;
 
 View::View(QWidget* parent) :
-    QGraphicsView(parent)
+    QGraphicsView(parent),
+    _scaleFactor(qLn(zoom_factor_min/1.0) / qLn(zoom_factor_min / zoom_factor_max))
 {
     // Scroll bars
     setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOn);


### PR DESCRIPTION
The default value of _scaleFactor is 1, and the calculated initial zoom is 10. This causes issues with the initial scaling. The default zoom should be 1, and then calculate the initial value of _scaleFactor from there. The result is 0.375804.