### PR TITLE
apply QT_NO_KEYWORDS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,6 @@ project(
     HOMEPAGE_URL https://github.com/simulton/qschematic
 )
 
-add_definitions(-DQT_NO_KEYWORDS)
-
 # User options
 set(OPTION_BUILD_SHARED_DEFAULT ON)
 if (MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ project(
     HOMEPAGE_URL https://github.com/simulton/qschematic
 )
 
+add_definitions(-DQT_NO_KEYWORDS)
+
 # User options
 set(OPTION_BUILD_SHARED_DEFAULT ON)
 if (MSVC)

--- a/demo/library/widget.cpp
+++ b/demo/library/widget.cpp
@@ -43,7 +43,7 @@ void Widget::itemClickedSlot(const QModelIndex& index)
         return;
     }
 
-    emit itemClicked(item);
+    Q_EMIT itemClicked(item);
 }
 
 void Widget::expandAll()

--- a/demo/library/widget.hpp
+++ b/demo/library/widget.hpp
@@ -25,13 +25,13 @@ namespace Library
 
         void expandAll();
 
-    signals:
+    Q_SIGNALS:
         void itemClicked(const QSchematic::Items::Item* item);
 
-    public slots:
+    public Q_SLOTS:
         void setPixmapScale(qreal scale);
 
-    private slots:
+    private Q_SLOTS:
         void itemClickedSlot(const QModelIndex& index);
 
     private:

--- a/qschematic/items/item.cpp
+++ b/qschematic/items/item.cpp
@@ -224,7 +224,7 @@ void Item::setSettings(const Settings& settings)
     _settings = settings;
 
     // Let everyone know
-    emit settingsChanged();
+    Q_EMIT settingsChanged();
 
     // Update
     update();
@@ -371,7 +371,7 @@ void Item::posChanged()
     const QPointF& newPos = pos();
     QVector2D movedBy(newPos - _oldPos);
     if (!movedBy.isNull()) {
-        emit moved(*this, movedBy);
+        Q_EMIT moved(*this, movedBy);
     }
 
     _oldPos = newPos;
@@ -379,7 +379,7 @@ void Item::posChanged()
 
 void Item::scenePosChanged()
 {
-    emit movedInScene(*this);
+    Q_EMIT movedInScene(*this);
 }
 
 void Item::rotChanged()
@@ -387,7 +387,7 @@ void Item::rotChanged()
     const qreal newRot = rotation();
     qreal rotationChange = newRot - _oldRot;
     if (!qFuzzyIsNull(rotationChange)) {
-        emit rotated(*this, rotationChange);
+        Q_EMIT rotated(*this, rotationChange);
     }
 
     _oldRot = newRot;

--- a/qschematic/items/item.hpp
+++ b/qschematic/items/item.hpp
@@ -129,7 +129,7 @@ namespace QSchematic::Items
         Scene* scene() const;
         virtual std::unique_ptr<QWidget> popup() const { return nullptr; }
 
-    signals:
+    Q_SIGNALS:
         void moved(Item& item, const QVector2D& movedBy);
         void movedInScene(Item& item);
         void rotated(Item& item, qreal rotation);
@@ -145,7 +145,7 @@ namespace QSchematic::Items
         bool isHighlighted() const;
         QVariant itemChange(QGraphicsItem::GraphicsItemChange change, const QVariant& value) override;
 
-    private slots:
+    private Q_SLOTS:
         void posChanged();
         void scenePosChanged();
         void rotChanged();

--- a/qschematic/items/label.cpp
+++ b/qschematic/items/label.cpp
@@ -95,7 +95,7 @@ void Label::setText(const QString& text)
 {
     _text = text;
     calculateTextRect();
-    emit textChanged(_text);
+    Q_EMIT textChanged(_text);
 }
 
 void Label::setFont(const QFont& font)
@@ -206,5 +206,5 @@ void Label::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWi
 
 void Label::mouseDoubleClickEvent([[maybe_unused]] QGraphicsSceneMouseEvent* event)
 {
-    emit doubleClicked();
+    Q_EMIT doubleClicked();
 }

--- a/qschematic/items/label.hpp
+++ b/qschematic/items/label.hpp
@@ -15,7 +15,7 @@ namespace QSchematic::Items
 
         friend class CommandLabelRename;
 
-    signals:
+    Q_SIGNALS:
         void textChanged(const QString& newText);
         void doubleClicked();
 

--- a/qschematic/items/rectitem.cpp
+++ b/qschematic/items/rectitem.cpp
@@ -113,7 +113,7 @@ void RectItem::setSize(QSizeF size)
     setTransformOriginPoint(sizeRect().center());
 
     sizeChangedEvent(oldSize, _size);
-    emit sizeChanged();
+    Q_EMIT sizeChanged();
 }
 
 void RectItem::setSize(qreal width, qreal height)

--- a/qschematic/items/rectitem.hpp
+++ b/qschematic/items/rectitem.hpp
@@ -17,7 +17,7 @@ namespace QSchematic::Items
         Q_OBJECT
         Q_DISABLE_COPY_MOVE(RectItem)
 
-    signals:
+    Q_SIGNALS:
         void sizeChanged();
 
     public:

--- a/qschematic/items/wire.cpp
+++ b/qschematic/items/wire.cpp
@@ -214,19 +214,19 @@ void Wire::setRenameAction(QAction* action)
 void Wire::prepend_point(const QPointF& point)
 {
     wire::prepend_point(point);
-    emit pointMoved(*this, wirePointsRelative().first());
+    Q_EMIT pointMoved(*this, wirePointsRelative().first());
 }
 
 void Wire::append_point(const QPointF& point)
 {
     wire::append_point(point);
-    emit pointMoved(*this, wirePointsRelative().last());
+    Q_EMIT pointMoved(*this, wirePointsRelative().last());
 }
 
 void Wire::insert_point(int index, const QPointF& point)
 {
     wire::insert_point(index, point);
-    emit pointMoved(*this, wirePointsRelative()[index]);
+    Q_EMIT pointMoved(*this, wirePointsRelative()[index]);
 }
 
 void Wire::removeFirstPoint()
@@ -255,7 +255,7 @@ void Wire::move_point_to(int index, const QPointF& moveTo)
     prepareGeometryChange();
     wire_system::wire::move_point_to(index, moveTo);
 
-    emit pointMoved(*this, wirePointsRelative()[index]);
+    Q_EMIT pointMoved(*this, wirePointsRelative()[index]);
     calculateBoundingRect();
     update();
 }

--- a/qschematic/items/wire.hpp
+++ b/qschematic/items/wire.hpp
@@ -45,7 +45,7 @@ namespace QSchematic::Items
         bool movingWirePoint() const;
         void rename_net();
 
-    signals:
+    Q_SIGNALS:
         void pointMoved(Wire& wire, point& point);
         void toggleLabelRequested();
 

--- a/qschematic/items/wirenet.hpp
+++ b/qschematic/items/wirenet.hpp
@@ -57,11 +57,11 @@ namespace QSchematic::Items
         QList<QPointF> points() const;
         std::shared_ptr<Label> label();
 
-    signals:
+    Q_SIGNALS:
         void highlightChanged(bool highlighted);
         void contextMenuRequested(const QPoint& pos);
 
-    private slots:
+    private Q_SLOTS:
         void labelHighlightChanged(const Item& item, bool highlighted);
         void wireHighlightChanged(const Item& item, bool highlighted);
         void toggleLabel();

--- a/qschematic/scene.cpp
+++ b/qschematic/scene.cpp
@@ -37,7 +37,7 @@ Scene::Scene(QObject* parent) :
     // Undo stack
     _undoStack = new QUndoStack(this);
     connect(_undoStack, &QUndoStack::cleanChanged, [this](bool isClean) {
-        emit isDirtyChanged(!isClean);
+        Q_EMIT isDirtyChanged(!isClean);
     });
 
     // Popup timer
@@ -219,7 +219,7 @@ Scene::setMode(int mode)
     update();
 
     // Let the world know
-    emit modeChanged(_mode);
+    Q_EMIT modeChanged(_mode);
 }
 
 int
@@ -249,7 +249,7 @@ Scene::clearIsDirty()
     if (_undoStack)
         _undoStack->setClean();
 
-    emit netlistChanged();
+    Q_EMIT netlistChanged();
 }
 
 void
@@ -294,8 +294,8 @@ Scene::addItem(const std::shared_ptr<Items::Item>& item)
     _items << item;
 
     // Let the world know
-    emit itemAdded(item);
-    emit netlistChanged();
+    Q_EMIT itemAdded(item);
+    Q_EMIT netlistChanged();
 
     return true;
 }
@@ -324,8 +324,8 @@ Scene::removeItem(const std::shared_ptr<Items::Item> item)
     update(itemBoundsToUpdate);
 
     // Let the world know
-    emit itemRemoved(item);
-    emit netlistChanged();
+    Q_EMIT itemRemoved(item);
+    Q_EMIT netlistChanged();
 
     // NOTE: In order to keep items alive through this entire event loop round,
     // otherwise crashes because Qt messes with items even after they're removed
@@ -741,7 +741,7 @@ Scene::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
                     _highlightedItem->setHighlighted(false);
                     itemHoverLeave(_highlightedItem->shared_from_this());
                     _highlightedItem->update();
-                    emit _highlightedItem->highlightChanged(*_highlightedItem, false);
+                    Q_EMIT _highlightedItem->highlightChanged(*_highlightedItem, false);
                     _highlightedItem = { };
                 }
 
@@ -749,7 +749,7 @@ Scene::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
                 item->setHighlighted(true);
                 itemHoverEnter(item->shared_from_this());
                 item->update();
-                emit item->highlightChanged(*item, true);
+                Q_EMIT item->highlightChanged(*item, true);
                 _highlightedItem = item->shared_from_this();
             }
 
@@ -758,7 +758,7 @@ Scene::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
                 _highlightedItem->setHighlighted(false);
                 itemHoverLeave(_highlightedItem->shared_from_this());
                 _highlightedItem->update();
-                emit _highlightedItem->highlightChanged(*_highlightedItem, false);
+                Q_EMIT _highlightedItem->highlightChanged(*_highlightedItem, false);
                 _highlightedItem = nullptr;
             }
 
@@ -1065,7 +1065,7 @@ Scene::updateNodeConnections(const Items::Node* node)
         }
     }
 
-    emit netlistChanged();
+    Q_EMIT netlistChanged();
 }
 
 void
@@ -1097,7 +1097,7 @@ Scene::wirePointMoved(wire& rawWire, int index)
         }
     }
 
-    emit netlistChanged();
+    Q_EMIT netlistChanged();
 }
 
 void
@@ -1116,7 +1116,7 @@ Scene::generateConnections()
             m_wire_manager->attach_wire_to_connector(wire.get(), connector.get());
     }
 
-    emit netlistChanged();
+    Q_EMIT netlistChanged();
 }
 
 /**
@@ -1135,7 +1135,7 @@ Scene::finishCurrentWire()
 //    _newWire->updatePosition();
     _newWire.reset();
 
-    emit netlistChanged();
+    Q_EMIT netlistChanged();
 }
 
 std::shared_ptr<Items::Wire>
@@ -1172,7 +1172,7 @@ Scene::connectors() const
 void
 Scene::itemHoverEnter(const std::shared_ptr<const Items::Item>& item)
 {
-    emit itemHighlighted(item);
+    Q_EMIT itemHighlighted(item);
 
     // Start popup timer
     _popupTimer->start(_settings.popupDelay);
@@ -1183,7 +1183,7 @@ Scene::itemHoverLeave([[maybe_unused]] const std::shared_ptr<const Items::Item>&
 {
     // ToDo: clear _highlightedItem ?
 
-    emit itemHighlighted(nullptr);
+    Q_EMIT itemHighlighted(nullptr);
 
     // Stop popup timer
     _popupTimer->stop();
@@ -1231,7 +1231,7 @@ Scene::removeLastWirePoint()
         }
     }
 
-    emit netlistChanged();
+    Q_EMIT netlistChanged();
 }
 
 /**
@@ -1282,7 +1282,7 @@ Scene::removeUnconnectedWires()
     for (const auto& wire : wiresToRemove)
         _undoStack->push(new Commands::ItemRemove(this, wire));
 
-    emit netlistChanged();
+    Q_EMIT netlistChanged();
 }
 
 bool
@@ -1299,7 +1299,7 @@ Scene::addWire(const std::shared_ptr<Items::Wire>& wire)
             return false;
     }
 
-    emit netlistChanged();
+    Q_EMIT netlistChanged();
 
     return true;
 }
@@ -1316,7 +1316,7 @@ Scene::removeWire(const std::shared_ptr<Items::Wire>& wire)
             m_wire_manager->detach_wire(connector.get());
     }
 
-    emit netlistChanged();
+    Q_EMIT netlistChanged();
 
     return m_wire_manager->remove_wire(wire);
 }

--- a/qschematic/scene.hpp
+++ b/qschematic/scene.hpp
@@ -182,7 +182,7 @@ namespace QSchematic
         QUndoStack*
         undoStack() const;
 
-    signals:
+    Q_SIGNALS:
         void modeChanged(int newMode);
         void isDirtyChanged(bool isDirty);
         void itemAdded(std::shared_ptr<Items::Item> item);
@@ -231,7 +231,7 @@ namespace QSchematic
         QPixmap
         renderBackground(const QRect& rect) const;
 
-    private slots:
+    private Q_SLOTS:
         void wirePointMoved(wire& rawWire, int index);
 
     private:

--- a/qschematic/view.cpp
+++ b/qschematic/view.cpp
@@ -222,7 +222,7 @@ View::updateScale()
     // Apply the new scale
     setTransform(QTransform::fromScale(zoom, zoom));
 
-    emit zoomChanged(zoom);
+    Q_EMIT zoomChanged(zoom);
 }
 
 void
@@ -230,7 +230,7 @@ View::setMode(const Mode newMode)
 {
     _mode = newMode;
 
-    emit modeChanged(_mode);
+    Q_EMIT modeChanged(_mode);
 }
 
 qreal

--- a/qschematic/view.hpp
+++ b/qschematic/view.hpp
@@ -65,11 +65,11 @@ namespace QSchematic
         qreal
         zoomValue() const;
 
-    signals:
+    Q_SIGNALS:
         void zoomChanged(qreal factor);
         void modeChanged(Mode newMode);
 
-    public slots:
+    public Q_SLOTS:
         /**
          * Set the zoom value.
          *

--- a/qschematic/wire_system/manager.cpp
+++ b/qschematic/wire_system/manager.cpp
@@ -246,7 +246,7 @@ void manager::point_moved_by_user(wire& rawWire, int index)
 {
     point point = rawWire.points().at(index);
 
-    emit wire_point_moved(rawWire, index);
+    Q_EMIT wire_point_moved(rawWire, index);
 
     // Detach wires
     if (index == 0 || index == rawWire.points_count() - 1){

--- a/qschematic/wire_system/manager.hpp
+++ b/qschematic/wire_system/manager.hpp
@@ -65,7 +65,7 @@ namespace wire_system
         void set_net_factory(std::function<std::shared_ptr<net>()> func);
         void connector_moved(const connectable* connector);
 
-    signals:
+    Q_SIGNALS:
         void wire_point_moved(wire& wire, int index);
 
     private:


### PR DESCRIPTION
In the case of using 3rd parties like [KDBindings](https://github.com/KDAB/KDBindings.git) to remove name clashes simply `QT_NO_KEYWORDS` must be applied.

Best Regards,
Iman.