### PR TITLE
enable ctest: Fixes issue #73

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,5 @@ jobs:
       - name: Build
         run: cmake --build build
 
-        # ToDo: Use CTest instead
       - name: Run tests
-        run: ./build/qschematic/wire_system/test/qschematic-wiresystem-tests
+        run:  ctest --test-dir build --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ project(
     HOMEPAGE_URL https://github.com/simulton/qschematic
 )
 
+# enable ctest
+enable_testing()
+
 # User options
 set(OPTION_BUILD_SHARED_DEFAULT ON)
 if (MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(
     HOMEPAGE_URL https://github.com/simulton/qschematic
 )
 
-# enable ctest
+# Enable CTest
 enable_testing()
 
 # User options

--- a/qschematic/wire_system/test/CMakeLists.txt
+++ b/qschematic/wire_system/test/CMakeLists.txt
@@ -55,3 +55,5 @@ target_link_libraries(
 	PUBLIC
 		${QSCHEMATIC_TARGET_INTERNAL}
 )
+
+add_test(NAME ${TARGET} COMMAND ${TARGET})


### PR DESCRIPTION
fixes #73 by allowing for ctest to run from the build-root dir